### PR TITLE
Implement scroll support

### DIFF
--- a/lib/src/macos/core_graphics_min_bindings.dart
+++ b/lib/src/macos/core_graphics_min_bindings.dart
@@ -102,6 +102,30 @@ class CoreGraphics {
           'CGEventGetLocation');
   late final _CGEventGetLocation =
       _CGEventGetLocationPtr.asFunction<CGPoint Function(CGEventRef)>();
+
+  CGEventRef CGEventCreateScrollWheelEvent(
+    CGEventSourceRef source,
+    CGScrollEventUnit units,
+    int wheelCount,
+    int wheel1,
+    int wheel2,
+  ) {
+    return _CGEventCreateScrollWheelEvent(
+      source,
+      units.value,
+      wheelCount,
+      wheel1,
+      wheel2,
+    );
+  }
+
+  late final _CGEventCreateScrollWheelEventPtr = _lookup<
+      ffi.NativeFunction<
+          CGEventRef Function(CGEventSourceRef, ffi.Uint32, ffi.Int32, ffi.Int32,
+              ffi.Int32)>>('CGEventCreateScrollWheelEvent');
+  late final _CGEventCreateScrollWheelEvent =
+      _CGEventCreateScrollWheelEventPtr.asFunction<
+          CGEventRef Function(CGEventSourceRef, int, int, int, int)>();
 }
 
 typedef CGDirectDisplayID = ffi.Uint32;
@@ -236,6 +260,20 @@ enum CGEventTapLocation {
         1 => kCGSessionEventTap,
         2 => kCGAnnotatedSessionEventTap,
         _ =>
-          throw ArgumentError('Unknown value for CGEventTapLocation: $value'),
+      throw ArgumentError('Unknown value for CGEventTapLocation: $value'),
+      };
+}
+
+enum CGScrollEventUnit {
+  kCGScrollEventUnitPixel(0),
+  kCGScrollEventUnitLine(1);
+
+  final int value;
+  const CGScrollEventUnit(this.value);
+
+  static CGScrollEventUnit fromValue(int value) => switch (value) {
+        0 => kCGScrollEventUnitPixel,
+        1 => kCGScrollEventUnitLine,
+        _ => throw ArgumentError('Unknown value for CGScrollEventUnit: $value'),
       };
 }

--- a/lib/src/mouse_base.dart
+++ b/lib/src/mouse_base.dart
@@ -112,3 +112,22 @@ void mouseUp(MouseButton button) {
           'Unsupported platform: ${Platform.operatingSystem}');
   }
 }
+
+/// Scroll the mouse wheel.
+///
+/// [deltaX] specifies horizontal scroll amount. Positive values scroll right
+/// and negative values scroll left. [deltaY] specifies vertical scroll amount.
+/// Positive values scroll up and negative values scroll down.
+void scroll({int deltaX = 0, int deltaY = 0}) {
+  switch (Platform.operatingSystem) {
+    case 'macos':
+      _scrollMacos(deltaX: deltaX, deltaY: deltaY);
+    case 'windows':
+      _scrollWindows(deltaX: deltaX, deltaY: deltaY);
+    case 'linux':
+      _scrollLinux(deltaX: deltaX, deltaY: deltaY);
+    default:
+      throw UnsupportedError(
+          'Unsupported platform: ${Platform.operatingSystem}');
+  }
+}

--- a/lib/src/mouse_linux.dart
+++ b/lib/src/mouse_linux.dart
@@ -108,6 +108,41 @@ void _mouseUpLinux(MouseButton button) {
   libX11Tests.XCloseDisplay(display);
 }
 
+void _scrollLinux({int deltaX = 0, int deltaY = 0}) {
+  final lib = x11Test.X11ExtensionXTest(DynamicLibrary.open(_soPath));
+  final display = lib.XOpenDisplay(nullptr);
+  if (display == nullptr) {
+    throw Exception('Faild to open display');
+  }
+
+  void sendButton(int button) {
+    _primitiveMouseDownLinux(display, button);
+    _primitiveMouseUpLinux(display, button);
+  }
+
+  if (deltaY > 0) {
+    for (var i = 0; i < deltaY; i++) {
+      sendButton(x11Test.Button4);
+    }
+  } else if (deltaY < 0) {
+    for (var i = 0; i < -deltaY; i++) {
+      sendButton(x11Test.Button5);
+    }
+  }
+
+  if (deltaX > 0) {
+    for (var i = 0; i < deltaX; i++) {
+      sendButton(x11Test.Button7);
+    }
+  } else if (deltaX < 0) {
+    for (var i = 0; i < -deltaX; i++) {
+      sendButton(x11Test.Button6);
+    }
+  }
+
+  lib.XCloseDisplay(display);
+}
+
 void _primitiveMouseDownLinux(Pointer<x11Test.Display> display, int button) {
   final libX11Tests = x11Test.X11ExtensionXTest(DynamicLibrary.open(_soPath));
   libX11Tests.XTestFakeButtonEvent(

--- a/lib/src/mouse_macos.dart
+++ b/lib/src/mouse_macos.dart
@@ -60,6 +60,19 @@ void _mouseUpMacos(MouseButton button) {
   );
 }
 
+void _scrollMacos({int deltaX = 0, int deltaY = 0}) {
+  final lib = cg.CoreGraphics(DynamicLibrary.open(_dylibPath));
+  final event = lib.CGEventCreateScrollWheelEvent(
+    nullptr,
+    cg.CGScrollEventUnit.kCGScrollEventUnitLine,
+    2,
+    deltaY,
+    deltaX,
+  );
+  lib.CGEventPost(cg.CGEventTapLocation.kCGHIDEventTap, event);
+  lib.CFRelease(event as cg.CFTypeRef);
+}
+
 cg.CGPoint _primitiveGetPositionMacos() {
   final lib = cg.CoreGraphics(DynamicLibrary.open(_dylibPath));
   final event = lib.CGEventCreate(nullptr);

--- a/lib/src/mouse_windows.dart
+++ b/lib/src/mouse_windows.dart
@@ -83,6 +83,41 @@ void _mouseUpWindows(MouseButton button) {
   }
 }
 
+void _scrollWindows({int deltaX = 0, int deltaY = 0}) {
+  if (deltaY != 0) {
+    final input = calloc<INPUT>();
+    input.ref.type = INPUT_TYPE.INPUT_MOUSE;
+    input.ref.mi.dx = 0;
+    input.ref.mi.dy = 0;
+    input.ref.mi.mouseData = deltaY;
+    input.ref.mi.dwFlags = MOUSE_EVENT_FLAGS.MOUSEEVENTF_WHEEL;
+    input.ref.mi.time = 0;
+    input.ref.mi.dwExtraInfo = 0;
+
+    final result = SendInput(1, input, sizeOf<INPUT>());
+    free(input);
+    if (result == 0) {
+      _throwLastError();
+    }
+  }
+  if (deltaX != 0) {
+    final input = calloc<INPUT>();
+    input.ref.type = INPUT_TYPE.INPUT_MOUSE;
+    input.ref.mi.dx = 0;
+    input.ref.mi.dy = 0;
+    input.ref.mi.mouseData = deltaX;
+    input.ref.mi.dwFlags = MOUSE_EVENT_FLAGS.MOUSEEVENTF_HWHEEL;
+    input.ref.mi.time = 0;
+    input.ref.mi.dwExtraInfo = 0;
+
+    final result = SendInput(1, input, sizeOf<INPUT>());
+    free(input);
+    if (result == 0) {
+      _throwLastError();
+    }
+  }
+}
+
 Never _throwLastError() {
   final errorCode = GetLastError();
   final buffer = calloc.allocate<Utf16>(1024);


### PR DESCRIPTION
## Summary
- add cross-platform `scroll` function to control mouse wheel
- implement OS-specific wheel handling
- expose minimal CoreGraphics bindings for scroll events

## Testing
- `dart format -o none --set-exit-if-changed lib` *(fails: `dart` not found)*
- `dart pub get` *(fails: `dart` not found)*
- `dart analyze` *(fails: `dart` not found)*
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582cc52e6c8333832d52b8a4c97333